### PR TITLE
Update python example.

### DIFF
--- a/python/inky/Dockerfile
+++ b/python/inky/Dockerfile
@@ -1,18 +1,25 @@
 FROM cgr.dev/chainguard/python:latest-dev as builder
 
+ENV LANG=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PATH="/inky/venv/bin:$PATH"
+
 WORKDIR /inky
 
+RUN python -m venv /inky/venv
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt --user
+RUN pip install --no-cache-dir -r requirements.txt
 
 FROM cgr.dev/chainguard/python:latest
 
 WORKDIR /inky
 
-# Make sure you update Python version in path
-COPY --from=builder /home/nonroot/.local/lib/python3.11/site-packages /home/nonroot/.local/lib/python3.11/site-packages
+ENV PYTHONUNBUFFERED=1
+ENV PATH="/venv/bin:$PATH"
 
 COPY inky.py inky.png ./
+COPY --from=builder /inky/venv /venv
 
 ENTRYPOINT [ "python", "/inky/inky.py" ]

--- a/python/inky/inky.py
+++ b/python/inky/inky.py
@@ -1,10 +1,10 @@
 '''import climage module to display images on terminal'''
-import climage
+from climage import convert, color_to_flags, color_types
 
 
 def main():
-    '''Take in PNG and output as ANSI to temrinal'''
-    output = climage.convert('inky.png', is_unicode=True)
+    '''Take in PNG and output as ANSI to terminal'''
+    output = convert('inky.png', is_unicode=True, **color_to_flags(color_types.truecolor))
     print(output)
 
 if __name__ == "__main__":

--- a/python/inky/requirements.txt
+++ b/python/inky/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==67.4.0
-climage==0.1.3
+climage==0.2.0
+setuptools==68.2.2


### PR DESCRIPTION
Use venv to hold dependencies for multistage build & bump requirements.