### PR TITLE
Added example of a Dev Container with a Chainguard base image

### DIFF
--- a/chainguard-go-devcontainer/.devcontainer/Dockerfile
+++ b/chainguard-go-devcontainer/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM chainguard/go:latest-dev
+
+# VS Code's requirements. posix-libc-utils for getent and ldconfig refreshes ld.so.cache for requirements script
+RUN apk update && apk add posix-libc-utils && ldconfig
+
+USER nonroot
+# These are used by the go extension for VS Code
+RUN    go install -v golang.org/x/tools/gopls@latest \
+    && go install -v honnef.co/go/tools/cmd/staticcheck@latest

--- a/chainguard-go-devcontainer/.devcontainer/devcontainer.json
+++ b/chainguard-go-devcontainer/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "golang-chainguard-devcontainer",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {}
+    },
+    "runArgs": [],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.Go"
+            ]
+        }
+    },
+    // 'forwardPorts' exposes ports from the container to your host
+    // "forwardPorts": [9000],
+    // 'postCreateCommand' runs after the container is created. eg to get dependencies
+    // "postCreateCommand": "go get .",
+    "remoteUser": "nonroot"
+}

--- a/chainguard-go-devcontainer/.gitignore
+++ b/chainguard-go-devcontainer/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/chainguard-go-devcontainer/README.md
+++ b/chainguard-go-devcontainer/README.md
@@ -1,0 +1,38 @@
+# Devcontainer using Chainguard's go image
+
+A minimal example of creating a Dev Container using a Chainguard distroless image.
+
+If you added the .devcontainer folder (and contents) at the root of your repo, VS Code would detect it and prompt you to open in a Dev Container.
+
+Instead, you can use Dev Containers: Open Folder in Container... and select this folder from command palette or quick actions. 
+
+If you open a terminal you should see the path in the prompt is preceded by the ID of the docker container. eg:
+```
+8317a7ac6809:/workspaces/edu-images-demos/chainguard-go-devcontainer$ 
+```
+
+It may take a minute to build the image the first time you use it.
+
+## Installing other tools
+
+Because this is a distroless container, not all tools are installed. Especially `sudo`, meaning you cannot easily add packages or run commands as root.
+
+If you need to add things to the running container, from your host machine you can use `docker` commands. eg to add sudo:
+
+```
+host$ docker exec -itu0 8317a7ac6809 bash
+bash-5.2# apk add -q sudo-rs shadow
+bash-5.2# echo "nonroot ALL = (ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+bash-5.2# echo y | pwck -q       
+```
+
+When you know what you need to install or run, add it to the Dockerfile in the .devcontainer directory so that it is present next time you run your Dev Container.
+
+## SSH/GPG 
+VSCode should take care of mounting your git config file into the container.
+
+You will need to add your ssh keys to `ssh-add` on your host machine.
+
+You may need to install gpg or gitsign for commit signing.
+
+See [VS Code Advanced Containers](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials) for more information.

--- a/chainguard-go-devcontainer/main.go
+++ b/chainguard-go-devcontainer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Minimal example")
+}


### PR DESCRIPTION
Added example of a Dev Container with a Chainguard base image.

To test, open this repo in VS Code. Open the command palette (F1) and **Dev Containers: Open Folder in Container...**

Open a terminal and check the command prompt is prefixed with a hex value (the ID of the container)