### PR TITLE
Adding php-fpm demo

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,8 @@
+## PHP Chainguard Image Demos
+
+This repository contains sample PHP code for Chainguard Images, for tutorials on [Chainguard Academy](https://edu.chainguard.dev/).
+
+- `namegen`: demo for building a distroless PHP image with a custom PHP CLI app as entry point, using `latest` and `latest-dev` variants.
+- `namegen-api`: demo for serving a web PHP app / API using the `latest-fpm` image variant in a Docker Compose setup using our Nginx image as web server.
+- `octo-facts`: Laravel demo. Uses the `laravel:latest` and `laravel:latest-dev` image variants.
+- `wordpress`: WordPress demo. Uses the `wordpress:latest` and `wordpress:latest-dev` image variants.

--- a/php/namegen-api/README.md
+++ b/php/namegen-api/README.md
@@ -1,0 +1,26 @@
+# namegen-api
+
+This demo uses the `latest-fpm` image variant to serve a web PHP app / API in a Docker Compose setup using our Nginx image as web server.
+
+## Usage
+### Bring the Environment Up
+```shell
+docker compose up
+```
+This will run a server on `http://localhost:8000`.
+
+### Make Requests
+
+```shell
+curl 0.0.0.0:8000
+```
+```shell
+{"animal":"octopus","adjective":"graceful"}
+```
+
+```shell
+curl '0.0.0.0:8000?animal=dog'
+```
+```shell
+{"animal":"dog","adjective":"ravishing"}
+```

--- a/php/namegen-api/docker-compose.yaml
+++ b/php/namegen-api/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  app:
+    image: cgr.dev/chainguard/php:latest-fpm
+    restart: unless-stopped
+    working_dir: /app
+    volumes:
+      - ./:/app
+
+  nginx:
+    image: cgr.dev/chainguard/nginx
+    restart: unless-stopped
+    ports:
+      - 8000:80
+    volumes:
+      - ./:/app
+      - ./nginx.conf:/etc/nginx/nginx.conf

--- a/php/namegen-api/index.php
+++ b/php/namegen-api/index.php
@@ -1,0 +1,9 @@
+<?php
+
+$animals = [ 'turtle', 'seagull', 'octopus', 'shark', 'whale', 'dolphin', 'walrus', 'penguin', 'seahorse'];
+$adjectives = [ 'ludicrous', 'mischievous', 'graceful', 'fortuitous', 'charming', 'ravishing', 'gregarious'];
+
+$chosenAdjective = $adjectives[array_rand($adjectives)];
+$chosenAnimal = $_GET['animal'] ?? $animals[array_rand($animals)];
+
+echo json_encode(['animal' => $chosenAnimal, 'adjective' => $chosenAdjective]);

--- a/php/namegen-api/nginx.conf
+++ b/php/namegen-api/nginx.conf
@@ -1,0 +1,29 @@
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+  worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        index index.php index.html;
+        root /app;
+        location ~ \.php$ {
+            try_files $uri =404;
+            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_pass app:9000;
+            fastcgi_index index.php;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+        }
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+            gzip_static on;
+        }
+    }
+}

--- a/php/namegen/README.md
+++ b/php/namegen/README.md
@@ -1,0 +1,15 @@
+# namegen
+
+This is a simple PHP CLI app that generates random names. It is used as a demo for building a distroless PHP image with a custom PHP CLI app as entry point, using `latest` and `latest-dev` variants.
+
+## Usage
+### Build the image
+```shell
+docker build -t chainguard/namegen:latest .
+```
+
+### Run the image
+
+```shell
+docker run --rm php-namegen get
+```


### PR DESCRIPTION
This PR adds a `namegen-api` demo to showcase our php-fpm image. I am currently working on [updating our PHP guide](https://github.com/chainguard-dev/edu/issues/1896) and noticed we didn't have yet an example for that image, so I'm including it now.