### PR TITLE
Adding Go demos

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,6 @@
+## Go Chainguard Image Demos
+
+This repository contains sample Go code for Chainguard Images, for tutorials on [Chainguard Academy](https://edu.chainguard.dev/).
+
+- `go-greeter`: CLI application example
+- `greet-server`: web application example

--- a/go/README.md
+++ b/go/README.md
@@ -2,5 +2,5 @@
 
 This repository contains sample Go code for Chainguard Images, for tutorials on [Chainguard Academy](https://edu.chainguard.dev/).
 
-- `go-greeter`: CLI application example
-- `greet-server`: web application example
+- [`go-greeter`](go-greeter/README.md): CLI application example
+- [`greet-server`](greet-server/README.md): web application example

--- a/go/go-greeter/Dockerfile
+++ b/go/go-greeter/Dockerfile
@@ -1,0 +1,7 @@
+FROM cgr.dev/chainguard/go AS builder
+COPY . /app
+RUN cd /app && go build -o go-greeter .
+
+FROM cgr.dev/chainguard/static
+COPY --from=builder /app/go-greeter /usr/bin/
+ENTRYPOINT ["/usr/bin/go-greeter"]

--- a/go/go-greeter/README.md
+++ b/go/go-greeter/README.md
@@ -1,0 +1,36 @@
+#  go-greeter
+
+The following build demonstrates a command line application with support for flags and positional arguments. The application prints a modifiable greeting message and provides usage information if the wrong number of arguments are passed by a user or the user passes an unrecognized flag.
+
+```shell
+docker build . -t go-greeter
+```
+Build the image, tagging it `go-greeter`:
+
+```shell
+docker build . -t go-greeter
+```
+
+Run the image:
+
+```shell
+docker run go-greeter
+```
+You should see output similar to the following:
+
+```shell
+Hello, Linky 🐙!
+```
+
+You can also pass in arguments that will be parsed by the Go CLI application:
+
+```shell
+docker run go-greeter -g Greetings "Chainguard user"
+```
+This will produce the following output:
+
+```shell   
+Greetings, Chainguard user!
+```
+
+The application will also share usage instructions when prompted with the `--help` flag or when invalid flags are passed.

--- a/go/go-greeter/go.mod
+++ b/go/go-greeter/go.mod
@@ -1,0 +1,3 @@
+module chainguard.dev/greet
+
+go 1.19

--- a/go/go-greeter/main.go
+++ b/go/go-greeter/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: hello [options] [name]\n")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+var (
+	greeting = flag.String("g", "Hello", "Greet with `greeting`")
+)
+
+func main() {
+	// Configure logging
+	log.SetFlags(0)
+	log.SetPrefix("hello: ")
+
+	// Parse flags.
+	flag.Usage = usage
+	flag.Parse()
+
+	// Parse and validate arguments.
+	name := "Linky 🐙"
+	args := flag.Args()
+	if len(args) >= 2 {
+		usage()
+	}
+	if len(args) >= 1 {
+		name = args[0]
+	}
+	if name == "" { // hello '' is an error
+		log.Fatalf("invalid name %q", name)
+	}
+
+	fmt.Printf("%s, %s!\n", *greeting, name)
+}

--- a/go/greet-server/Dockerfile
+++ b/go/greet-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM cgr.dev/chainguard/go AS builder
+COPY . /app
+RUN cd /app && go build
+
+FROM cgr.dev/chainguard/glibc-dynamic
+COPY --from=builder /app/greet-server /usr/bin/
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/bin/greet-server"]

--- a/go/greet-server/README.md
+++ b/go/greet-server/README.md
@@ -1,0 +1,29 @@
+# greet-server
+
+The following build demonstrates an application that's accessible by HTTP server. The application renders a simple message that changes based on the URI.
+
+Build the image, tagging it `greet-server`:
+
+```shell
+docker build . -t greet-server
+```
+
+Run the image:
+
+```shell
+docker run -p 8080:8080 greet-server
+```
+
+Visit `http://0.0.0.0:8080/` using a web browser on your host machine. You should see the following:
+
+```shell
+Hello, Linky 🐙!
+```
+
+Changes to the URI will be routed to the application. Try visiting http://0.0.0.0:8080/Chainguard%20Customer. You should see the following output:
+
+```shell
+Hello, Chainguard Customer!
+```
+
+The application will also share version information at http://0.0.0.0:8080/version.

--- a/go/greet-server/README.md
+++ b/go/greet-server/README.md
@@ -20,10 +20,10 @@ Visit `http://0.0.0.0:8080/` using a web browser on your host machine. You shoul
 Hello, Linky 🐙!
 ```
 
-Changes to the URI will be routed to the application. Try visiting http://0.0.0.0:8080/Chainguard%20Customer. You should see the following output:
+Changes to the URI will be routed to the application. Try visiting [http://0.0.0.0:8080/Chainguard%20Customer](http://0.0.0.0:8080/Chainguard%20Customer). You should see the following output:
 
 ```shell
 Hello, Chainguard Customer!
 ```
 
-The application will also share version information at http://0.0.0.0:8080/version.
+The application will also share version information at [http://0.0.0.0:8080/version](http://0.0.0.0:8080/version).

--- a/go/greet-server/go.mod
+++ b/go/greet-server/go.mod
@@ -1,0 +1,3 @@
+module chainguard.dev/greet-server
+
+go 1.19

--- a/go/greet-server/main.go
+++ b/go/greet-server/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: helloserver [options]\n")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+var (
+	greeting = flag.String("g", "Hello", "Greet with `greeting`")
+	addr     = flag.String("addr", "0.0.0.0:8080", "address to serve")
+)
+
+func main() {
+	// Parse flags.
+	flag.Usage = usage
+	flag.Parse()
+
+	// Parse and validate arguments (none).
+	args := flag.Args()
+	if len(args) != 0 {
+		usage()
+	}
+
+	// Register handlers. for greeting and version
+	http.HandleFunc("/", greet)
+	http.HandleFunc("/version", version)
+
+	log.Printf("serving http://%s\n", *addr)
+	log.Fatal(http.ListenAndServe(*addr, nil))
+}
+
+func version(w http.ResponseWriter, r *http.Request) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		http.Error(w, "no build information available", 500)
+		return
+	}
+
+	fmt.Fprintf(w, "<!DOCTYPE html>\n<pre>\n")
+	fmt.Fprintf(w, "%s\n", html.EscapeString(info.String()))
+}
+
+func greet(w http.ResponseWriter, r *http.Request) {
+	name := strings.Trim(r.URL.Path, "/")
+	if name == "" {
+		name = "Linky 🐙"
+	}
+
+	fmt.Fprintf(w, "<!DOCTYPE html>\n")
+	fmt.Fprintf(w, "%s, %s!\n", *greeting, html.EscapeString(name))
+}


### PR DESCRIPTION
This PR adds two Go demos from the [Go Image README](https://images.chainguard.dev/directory/image/go/overview). These demos will be used on the update I'm working on for our Go Getting Started guide, as part of our maintenance sprint.

Thanks for the new demos @smythp !