### PR TITLE
Adding dotnet image from cs-workshop repo

### DIFF
--- a/dotnet/demo.sh
+++ b/dotnet/demo.sh
@@ -1,0 +1,24 @@
+#! env bash
+. ../base.sh
+
+for i in $(docker images -q dotnet-example); do
+  docker rmi $i
+done
+
+clear
+banner "Here's an existing Dockerfile for a dotnet application."
+pe "$BATCAT ./not-linky/Dockerfile"
+pe "docker build -t dotnet-example:not-linky ./not-linky"
+pe "docker run --rm dotnet-example:not-linky"
+
+banner "Let's migrate it to a Chainguard image."
+pe "git diff --no-index -U1000 ./not-linky/Dockerfile ./linky/Dockerfile"
+pe "docker build -t dotnet-example:linky ./linky"
+pe "docker run --rm dotnet-example:linky"
+
+banner "It should be a bit smaller."
+pe "docker images dotnet-example"
+
+banner "And have significantly less vulnerabilities."
+pe "grype dotnet-example:not-linky"
+pe "grype dotnet-example:linky"

--- a/dotnet/linky/.dockerignore
+++ b/dotnet/linky/.dockerignore
@@ -1,0 +1,12 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.trx
+**/*.md
+**/*.ps1
+**/*.cmd
+**/*.sh

--- a/dotnet/linky/Dockerfile
+++ b/dotnet/linky/Dockerfile
@@ -1,0 +1,22 @@
+# Learn about building .NET container images:
+# https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
+ARG IMAGE_REGISTRY="cgr.dev/chainguard"
+FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet-sdk:latest-dev AS build
+ARG TARGETARCH
+WORKDIR /source
+
+# Copy project file and restore as distinct layers
+COPY --link *.csproj .
+# switch to root user in order to do restore
+USER 0
+RUN dotnet restore -a $TARGETARCH
+
+# Copy source code and publish app
+COPY --link . .
+RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+
+# Runtime stage
+FROM ${IMAGE_REGISTRY}/aspnet-runtime:latest
+WORKDIR /app
+COPY --link --from=build /app .
+ENTRYPOINT ["./dotnetapp"]

--- a/dotnet/linky/Program.cs
+++ b/dotnet/linky/Program.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using static System.Console;
+
+// Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
+// Ascii text: https://ascii.co.uk/text (Univers font)
+WriteLine("""
+******************************************************************************++++++++++++++++++++++
+*************************************************************************+++++++++++++++++++++++++++
+*************************************************************************+++++++++++++++++++++++++++
+************************************************++++******************++++++++++++++++++++++++++++++
+******************************************+-:..........:-+**********++++++++++++++++++++++++++++++++
+***************************************+:.....:-=++=-:.....:=****+++++++++++++++++++++++++++++++++++
+*************************************-....=**************=....-+*+++++++++++++++++++++++++++++++++++
+***********************************=...:***+.....:*********+:...=+++++++++++++++++++++++++++++++++++
+**********************************:..:****-......-************:..:++++++++++++++++++++++++++++++++++
+********************************+...=**-:*+....-***************=...=++++++++++++++++++++++++++++++++
+*******************************+...+*=...+**********************+...=+++++++++++++++++++++++++++++++
+******************************+...***+:-*************************+...=++++++++++++++++++++++++++++++
+*****************************+...*********************************+...++++++++++++++++++++++++++++++
+*****************************:..+**********************************=..:+++++++++++++++++++++++++++++
+****************************=..-***********************************+:..=++++++++++++++++++++++++++++
+***************************+...**********-....:+**********-....:+**++...++++++++++++++++++++++++++++
+***************************=..:********=..=+*+..:*******+..=+++:.:+++:..=+++++++++++++++++++++++++++
+***************************=..-********..****:...+*****+..+**+-...=++-..=+++++++++++++++++++++++++++
+***************************=..-********..+*****:.+*****+..+**+*+:.=++-..-+++++++++++++++++++++++++++
+***************************=..:********=..-++=..-*******+..-===..-+++:..=+++++++++++++++++++++++++++
+***************************+...+*********=:..:-+*********+=:..:-+++++...++++++++++++++++++++++++++++
+****************************+...*************************+++++++++++...=++++++++++++++++++++++++++++
+************************+=-:....:**********************++++++++++++:....:-=+++++++++++++++++++++++++
+*******************+=:.......:-+********************+++++++++++++++++-:.... ..:-=+++++++++++++++++++
+****************+:.....:=+************************++++++++++++++++++++++++=-:.....:=++++++++++++++++
+***************-...=****************************++++++++++++++++++++++++++++++++-...-+++++++++++++++
+**************+..:*****************************+++++++++++++++++++++++++++++++++++...+++++++++++++++
+***************-..:**************************+++++++++++++++++++++++++++++++++++=:..:+++++++++++++++
+****************-.. ....::::-*************++++++++++++++=++++++++++++++::::........-++++++++++++++++
+******************+=:......=**************=-++++++++++++-=++++++++++++++-......:-+++++++++++++++++++
+***********************=..-*************+-.-++++++++++++:.-++++++++++++++-..-+++++++++++++++++++++++
+******************+++++=..-***********+=....++++++++++++....-++++++++++++:..=+++++++++++++++++++++++
+*****************+++++*+:...-++**++=-.......-++++++++++-.......:=+++++=-...:++++++++++++++++++++++++
+***************++*++++++++:...........:=++:..-++++++++-..:++=:...........:=+++++++++++++++++++++++++
+*************++++++++++++++++======++++++++:...=++++=...:+++++++===--==+++++++++++++++++++++++++++++
+**********++*+++++++++++++++++++++++++++++++=..........=++++++++++++++++++++++++++++++++++++++++++++
+**********+++++++++++++++++++++++++++++++++++++-::::=+++++++++++++++++++++++++++++++++++++++++++++++
+********++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+*****+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+""");
+
+const double Mebi = 1024 * 1024;
+const double Gibi = Mebi * 1024;
+GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
+long totalMemoryBytes = gcInfo.TotalAvailableMemoryBytes;
+
+// OS and .NET information
+WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
+WriteLine($"{nameof(RuntimeInformation.OSDescription)}: {RuntimeInformation.OSDescription}");
+WriteLine($"{nameof(RuntimeInformation.FrameworkDescription)}: {RuntimeInformation.FrameworkDescription}");
+WriteLine();
+
+// Environment information
+WriteLine($"{nameof(Environment.UserName)}: {Environment.UserName}");
+WriteLine($"HostName : {Dns.GetHostName()}");
+WriteLine();
+
+// Hardware information
+WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
+WriteLine($"{nameof(GCMemoryInfo.TotalAvailableMemoryBytes)}: {totalMemoryBytes} ({GetInBestUnit(totalMemoryBytes)})");
+
+string[] memoryLimitPaths = new string[] 
+{
+    "/sys/fs/cgroup/memory.max",
+    "/sys/fs/cgroup/memory.high",
+    "/sys/fs/cgroup/memory.low",
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+};
+
+string[] currentMemoryPaths = new string[] 
+{
+    "/sys/fs/cgroup/memory.current",
+    "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+};
+
+// cgroup information
+if (OperatingSystem.IsLinux() &&
+    GetBestValue(memoryLimitPaths, out long memoryLimit, out string? bestMemoryLimitPath) &&
+    memoryLimit > 0)
+{
+    // get memory cgroup information
+    GetBestValue(currentMemoryPaths, out long currentMemory, out string? memoryPath);
+
+    WriteLine($"cgroup memory constraint: {bestMemoryLimitPath}");
+    WriteLine($"cgroup memory limit: {memoryLimit} ({GetInBestUnit(memoryLimit)})");
+    WriteLine($"cgroup memory usage: {currentMemory} ({GetInBestUnit(currentMemory)})");
+    WriteLine($"GC Hard limit %: {(double)totalMemoryBytes/memoryLimit * 100:N0}");
+}
+
+string GetInBestUnit(long size)
+{
+    if (size < Mebi)
+    {
+        return $"{size} bytes";
+    }
+    else if (size < Gibi)
+    {
+        double mebibytes = size / Mebi;
+        return $"{mebibytes:F} MiB";
+    }
+    else
+    {
+        double gibibytes = size / Gibi;
+        return $"{gibibytes:F} GiB";
+    }
+}
+
+bool GetBestValue(string[] paths, out long limit, [NotNullWhen(true)] out string? bestPath)
+{
+    foreach (string path in paths)
+    {
+        if (Path.Exists(path) &&
+            long.TryParse(File.ReadAllText(path), out limit))
+        {
+            bestPath = path;
+            return true;
+        }
+    }
+
+    bestPath = null;
+    limit = 0;
+    return false;
+}

--- a/dotnet/linky/dotnetapp.csproj
+++ b/dotnet/linky/dotnetapp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/linky/run-demo.sh
+++ b/dotnet/linky/run-demo.sh
@@ -1,0 +1,11 @@
+# build the image
+docker build -t dotnetapp-linky .
+
+# run the image
+docker run --rm dotnetapp-linky
+
+# scan the image
+grype dotnetapp-linky
+
+# compare image size
+docker image ls | grep dotnetapp

--- a/dotnet/not-linky/.dockerignore
+++ b/dotnet/not-linky/.dockerignore
@@ -1,0 +1,12 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.trx
+**/*.md
+**/*.ps1
+**/*.cmd
+**/*.sh

--- a/dotnet/not-linky/Dockerfile
+++ b/dotnet/not-linky/Dockerfile
@@ -1,0 +1,21 @@
+# Learn about building .NET container images:
+# https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md
+ARG IMAGE_REGISTRY="mcr.microsoft.com"
+FROM --platform=$BUILDPLATFORM ${IMAGE_REGISTRY}/dotnet/sdk:9.0 AS build
+ARG TARGETARCH
+WORKDIR /source
+
+# Copy project file and restore as distinct layers
+COPY --link *.csproj .
+RUN dotnet restore -a $TARGETARCH
+
+# Copy source code and publish app
+COPY --link . .
+RUN dotnet publish -a $TARGETARCH --no-restore -o /app
+
+# Runtime stage
+FROM ${IMAGE_REGISTRY}/dotnet/runtime:9.0
+WORKDIR /app
+COPY --link --from=build /app .
+USER $APP_UID
+ENTRYPOINT ["./dotnetapp"]

--- a/dotnet/not-linky/Program.cs
+++ b/dotnet/not-linky/Program.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Net;
+using System.Runtime.InteropServices;
+using static System.Console;
+
+// Variant of https://github.com/dotnet/core/tree/main/samples/dotnet-runtimeinfo
+// Ascii text: https://ascii.co.uk/text (Univers font)
+
+WriteLine("""
+         42                                                    
+         42              ,d                             ,d     
+         42              42                             42     
+ ,adPPYb,42  ,adPPYba, MM42MMM 8b,dPPYba,   ,adPPYba, MM42MMM  
+a8"    `Y42 a8"     "8a  42    42P'   `"8a a8P_____42   42     
+8b       42 8b       d8  42    42       42 8PP!!!!!!!   42     
+"8a,   ,d42 "8a,   ,a8"  42,   42       42 "8b,   ,aa   42,    
+ `"8bbdP"Y8  `"YbbdP"'   "Y428 42       42  `"Ybbd8"'   "Y428  
+
+""");
+
+const double Mebi = 1024 * 1024;
+const double Gibi = Mebi * 1024;
+GCMemoryInfo gcInfo = GC.GetGCMemoryInfo();
+long totalMemoryBytes = gcInfo.TotalAvailableMemoryBytes;
+
+// OS and .NET information
+WriteLine($"{nameof(RuntimeInformation.OSArchitecture)}: {RuntimeInformation.OSArchitecture}");
+WriteLine($"{nameof(RuntimeInformation.OSDescription)}: {RuntimeInformation.OSDescription}");
+WriteLine($"{nameof(RuntimeInformation.FrameworkDescription)}: {RuntimeInformation.FrameworkDescription}");
+WriteLine();
+
+// Environment information
+WriteLine($"{nameof(Environment.UserName)}: {Environment.UserName}");
+WriteLine($"HostName : {Dns.GetHostName()}");
+WriteLine();
+
+// Hardware information
+WriteLine($"{nameof(Environment.ProcessorCount)}: {Environment.ProcessorCount}");
+WriteLine($"{nameof(GCMemoryInfo.TotalAvailableMemoryBytes)}: {totalMemoryBytes} ({GetInBestUnit(totalMemoryBytes)})");
+
+string[] memoryLimitPaths = new string[] 
+{
+    "/sys/fs/cgroup/memory.max",
+    "/sys/fs/cgroup/memory.high",
+    "/sys/fs/cgroup/memory.low",
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+};
+
+string[] currentMemoryPaths = new string[] 
+{
+    "/sys/fs/cgroup/memory.current",
+    "/sys/fs/cgroup/memory/memory.usage_in_bytes",
+};
+
+// cgroup information
+if (OperatingSystem.IsLinux() &&
+    GetBestValue(memoryLimitPaths, out long memoryLimit, out string? bestMemoryLimitPath) &&
+    memoryLimit > 0)
+{
+    // get memory cgroup information
+    GetBestValue(currentMemoryPaths, out long currentMemory, out string? memoryPath);
+
+    WriteLine($"cgroup memory constraint: {bestMemoryLimitPath}");
+    WriteLine($"cgroup memory limit: {memoryLimit} ({GetInBestUnit(memoryLimit)})");
+    WriteLine($"cgroup memory usage: {currentMemory} ({GetInBestUnit(currentMemory)})");
+    WriteLine($"GC Hard limit %: {(double)totalMemoryBytes/memoryLimit * 100:N0}");
+}
+
+string GetInBestUnit(long size)
+{
+    if (size < Mebi)
+    {
+        return $"{size} bytes";
+    }
+    else if (size < Gibi)
+    {
+        double mebibytes = size / Mebi;
+        return $"{mebibytes:F} MiB";
+    }
+    else
+    {
+        double gibibytes = size / Gibi;
+        return $"{gibibytes:F} GiB";
+    }
+}
+
+bool GetBestValue(string[] paths, out long limit, [NotNullWhen(true)] out string? bestPath)
+{
+    foreach (string path in paths)
+    {
+        if (Path.Exists(path) &&
+            long.TryParse(File.ReadAllText(path), out limit))
+        {
+            bestPath = path;
+            return true;
+        }
+    }
+
+    bestPath = null;
+    limit = 0;
+    return false;
+}

--- a/dotnet/not-linky/dotnetapp.csproj
+++ b/dotnet/not-linky/dotnetapp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <EnableSdkContainerSupport>true</EnableSdkContainerSupport>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet/not-linky/run-demo.sh
+++ b/dotnet/not-linky/run-demo.sh
@@ -1,0 +1,11 @@
+# build the image
+docker build -t dotnetapp-not-linky .
+
+# run the image
+docker run --rm dotnetapp-not-linky
+
+# scan the image
+grype dotnetapp-not-linky
+
+# compare image size
+docker image ls | grep dotnetapp

--- a/dotnet/readme.md
+++ b/dotnet/readme.md
@@ -1,0 +1,70 @@
+# Dotnet Migration Example
+
+## Overview
+This directory contains an example of migrating a dotnet application from upstream Microsoft dotnet image to the Chainguard dotnet image.
+
+The example is a simple application that takes an example from the microsoft dotnet examples github repo and migrates it to using Chainguard dotnet images.
+
+The dotnet upstream example comes directly from MSFT's github [repo](https://github.com/dotnet/dotnet-docker/blob/main/samples/README.md). The examples in this directory were originally hosted in Chainguard's [`cs-workshop` directory](https://github.com/chainguard-demo/cs-workshop). 
+
+## Steps
+### Using upstream image:
+1. cd the not-linky directory
+```
+cd not-linky
+```
+2. Build the application
+
+```
+docker build -t dotnet-notlinky .
+```
+3. Run the image:
+
+```
+docker run --rm dotnet-notlinky
+```
+4. Scan the image:
+```
+grype dotnet-notlinky
+```
+
+### Takeaways:
+1. Note that the upstream image runs by root as default, so in the dockerfile they set a non-root user.
+2. Vulnerabilities from the grype scan
+3. Number of packages, files, etc.
+
+### Using Chainguard images:
+1. cd the linky directory
+```
+cd linky
+```
+2. Build the application
+
+```
+docker build -t dotnet-linky .
+```
+3. Run the image:
+
+```
+docker run --rm dotnet-linky
+```
+4. Scan the image:
+```
+grype dotnet-linky
+```
+
+### Compare Image Sizes:
+```
+docker image list | grep dotnet-
+```
+
+### Takeaways:
+1. Note that Chainguard image does not run as a root user (by default)
+2. 0 Vulnerabilities from the grype scan
+3. Number of packages, files, etc.
+
+## Compare Dockerfiles
+1. Note that container registries are different.
+2. Both dockerfiles use multistage builds.
+3. MSFT upstream image runs as root by default, the Chainguard image does not, so we need to switch to the root user in the Chainguard dockerfile to run a privledged command like dotnet restore (which installs dependencies for the app)
+4. In the runtime stage the MSFT example switches to a non-root user, this is not needed in the Chainguard dockerfile because by default Chainguard images do not run as root 


### PR DESCRIPTION
This PR adds the `dotnet` example from the `cs workshop` repository: https://github.com/chainguard-demo/cs-workshop/tree/main/dotnet

This will support forthcoming a .NET migration doc.